### PR TITLE
Step3: enable source maps for production bundles

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ const ourModules=path.resolve(__dirname,'node_modules')
 
 module.exports = {
   mode: 'production',
+  devtool: 'source-map',
   entry: './src/index.ts',
   plugins: [
     new CleanWebpackPlugin(),


### PR DESCRIPTION
Requires explicitly importing jquery in Utils.js as I could not provide it as a global variable.