### PR TITLE
Step9: include ES6 polyfills

### DIFF
--- a/collect-karma-tests.js
+++ b/collect-karma-tests.js
@@ -1,3 +1,5 @@
+require('babel-polyfill')
+
 //create globals used by production code:
 require('./setup-jest')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2818,6 +2818,23 @@
         }
       }
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+        }
+      }
+    },
     "babel-preset-current-node-syntax": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
+    "babel-polyfill": "^6.26.0",
     "backbone": "1.2.3",
     "backbone.babysitter": "0.1.12",
     "backbone.marionette": "^2.4.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import 'babel-polyfill'
 import 'jquery'
 import 'select2'
 import 'modules/Helpers' //registers Handlebars helpers
@@ -16,4 +17,8 @@ element.innerHTML = new Greeter('TS World').greet()
 
 document.body.appendChild(element);
 
+// Test ES6 polyfills: String.prototype.includes is missing in Firefox versions < 40
+// https://caniuse.com/#feat=es6-string-includes
+let check = 'JavaScript'.includes('Java')
+console.log(`'JavaScript'.includes('Java')=${check}`)
 


### PR DESCRIPTION
Tested with Firefox 26.0 which does not have Promises.
Firefox 33.1 already has Promises and it works without babel-polyfill.
Both browsers fail to open "Add Tag" dialog because of duplicated object keys.
(issue #9)