### PR TITLE
Step 11: Bundle used polyfills only

### DIFF
--- a/collect-karma-tests.js
+++ b/collect-karma-tests.js
@@ -1,4 +1,3 @@
-require('babel-polyfill')
 
 //create globals used by production code:
 require('./setup-jest')

--- a/package-lock.json
+++ b/package-lock.json
@@ -2911,23 +2911,6 @@
         }
       }
     },
-    "babel-polyfill": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "regenerator-runtime": "^0.10.5"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.10.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-        }
-      }
-    },
     "babel-preset-current-node-syntax": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.2.tgz",
@@ -2963,6 +2946,13 @@
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+        }
       }
     },
     "backbone": {
@@ -3970,9 +3960,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
     "core-js-compat": {
       "version": "3.6.5",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
-    "babel-polyfill": "^6.26.0",
     "backbone": "1.2.3",
     "backbone.babysitter": "0.1.12",
     "backbone.marionette": "^2.4.3",
@@ -69,6 +68,7 @@
     "backgrid-sizeable-columns": "0.1.1",
     "bootstrap": "3.3.7",
     "bootstrap-daterangepicker": "2.1.25",
+    "core-js": "^3.6.5",
     "d3": "3.5.17",
     "d3-tip": "0.6.8",
     "dagre-d3": "0.6.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import 'babel-polyfill'
 import 'jquery'
 import 'select2'
 import 'modules/Helpers' //registers Handlebars helpers

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,22 @@ const atlasExternalLib=path.resolve(atlasPubDir,'js/external_lib')
 const atlasJsDir=path.resolve(__dirname,'src')
 const ourModules=path.resolve(__dirname,'node_modules')
 
+var babelLoader = {
+  loader: 'babel-loader',
+  options: {
+    presets: [
+      [
+        "@babel/preset-env",
+        {
+          "useBuiltIns": "usage",
+          "corejs": 3
+        }
+      ]
+    ],
+    plugins: ["@babel/plugin-proposal-throw-expressions"],
+  }
+};
+
 module.exports = {
   mode: 'production',
   devtool: 'source-map',
@@ -40,26 +56,25 @@ module.exports = {
     rules: [
       {
         test: /\.m?js$/,
-        exclude: /(node_modules)/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            presets: ['@babel/preset-env'],
-            plugins: ["@babel/plugin-proposal-throw-expressions"],
-          }
-        }
+        exclude: /(node_modules|pnotify)/,
+        use: [
+          babelLoader,
+        ]
       },
       {
         test: /\.tsx?$/,
-        use: {
-          loader: 'ts-loader',
-          options: {
-            /**
-             * A value of false makes troubles with HtmlWebpackPlugin
-             */
-            transpileOnly: true
+        use: [
+          babelLoader,
+          {
+            loader: 'ts-loader',
+            options: {
+              /**
+               * A value of false makes troubles with HtmlWebpackPlugin
+               */
+              transpileOnly: true
+            }
           }
-        },
+        ],
         exclude: /node_modules/,
       },
       {


### PR DESCRIPTION
Enabled babel-loader also for TypeScript sources.
Instead of importing all polyfills, let babel-preset-env  import only the polyfills that are actually needed.
https://babeljs.io/docs/en/babel-preset-env#usebuiltins-usage
